### PR TITLE
Merge description source-parent pr from symphony-das master

### DIFF
--- a/src/main/matlab/+symphonyui/+app/DocumentationService.m
+++ b/src/main/matlab/+symphonyui/+app/DocumentationService.m
@@ -123,7 +123,11 @@ classdef DocumentationService < handle
                 error([description ' is not an available source description for the current parent type']);
             end
             constructor = str2func(description);
-            s = obj.session.getPersistor().addSource(parent, constructor());
+            if nargin(constructor) == 1
+                s = obj.session.getPersistor().addSource(parent, constructor(parent));
+            else
+                s = obj.session.getPersistor().addSource(parent, constructor());
+            end
             notify(obj, 'AddedSource', symphonyui.app.AppEventData(s));
         end
 


### PR DESCRIPTION
Merge #50 pr from symphonydas master. Adds ability for nested source descriptions to gain access to parent source fields. Can be used to prevent user from adding nested source when parent source is incomplete. 